### PR TITLE
Set websocket max size to 16MB

### DIFF
--- a/web/services/hass_client.py
+++ b/web/services/hass_client.py
@@ -151,7 +151,7 @@ class HASSClient:
         ws_url = ws_url + "/api/websocket"
 
         logger.info("Connecting to %s", ws_url)
-        self._ws = await websockets.connect(ws_url)
+        self._ws = await websockets.connect(ws_url, max_size=16 * 1024 * 1024)  # 16MB - This can be made larger or set to NONE if we really want it that way... 
 
         # Step 1: Receive auth_required
         msg = await self._recv_json()


### PR DESCRIPTION
**Fix:** Increase WebSocket max_size to prevent 1009 frame too large error on large HA instances

The initial websocket connection had a default 1MB frame size limit, which works fine for smaller Home Assistant instances. 

However, larger HA installs with many entities can exceed this limit during the `get_states` call, causing a 1009 error and failed connection: (Mine said
`sent 1009 (message too big) frame exceeds limit of 1048576 bytes; no close frame received` )

I've increased the limit to 16MB in `services/hass_client.py` which should cover the vast majority of HA instances.

**Potential future improvement**: This could be made user-configurable via a .env variable (e.g. `HA_WS_MAX_SIZE_MB=16`) so users with exceptionally large instances can tune it themselves without touching the code.