### PR TITLE
Fix: Multiple bug fixes for HA integration, session routing, and FordPass unit handling

### DIFF
--- a/web/services/hass_client.py
+++ b/web/services/hass_client.py
@@ -192,18 +192,26 @@ class HASSClient:
             logger.info("Loaded %d entity states from HA", len(self._entity_states))
             self._detect_vin()
 
-            # Detect FordPass preferred units from elveh sensor attributes
+            # Detect FordPass preferred distance units from elveh sensor attributes
             if self._ha_config:
                 for eid, state in self._entity_states.items():
                     if eid.startswith("sensor.fordpass_") and eid.endswith("_elveh"):
                         uom = (state.get("attributes", {}).get("unit_of_measurement") or "").lower()
                         self._ha_config["_fordpass_distance_unit"] = "mi" if "mi" in uom else "km"
-                        # Temperature unit: FordPass uses F when distance is mi, C when km
-                        self._ha_config["_fordpass_temp_unit"] = "degF" if "mi" in uom else "degC"
-                        logger.info("FordPass preferred units: distance=%s, temp=%s",
-                                    self._ha_config["_fordpass_distance_unit"],
+                        logger.info("FordPass preferred units: distance=%s",
+                                    self._ha_config["_fordpass_distance_unit"])
+                        break
+                        
+            # Detect temperature units from fordpass - can be different from distance units.
+            if self._ha_config:
+                for eid, state in self._entity_states.items():
+                    if eid.startswith("sensor.fordpass_") and eid.endswith("outsidetemp"):
+                        uom = (state.get("attributes", {}).get("unit_of_measurement") or "")
+                        self._ha_config["_fordpass_temp_unit"] = "degF" if "°F" in uom else "degC"
+                        logger.info("FordPass preferred units: temp=%s",
                                     self._ha_config["_fordpass_temp_unit"])
                         break
+                        
 
         # Step 6: Process initial snapshot through event handler
         # This captures current state (e.g. last energytransferlogentry) as DB records
@@ -234,6 +242,7 @@ class HASSClient:
 
         self._health["connected"] = True
         self._health["connection_state"] = "connected"
+        self._health["last_error"] = None  
         logger.info("HASS client fully connected and subscribed")
 
     async def _event_loop(self) -> None:
@@ -359,8 +368,8 @@ class HASSClient:
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
                 resp = await client.get(
-                    f"{ha_url}/api/history/period/{start_time}",
-                    params={"filter_entity_id": entity_id},
+                    f"{ha_url}/api/history/period",
+                    params={"filter_entity_id": entity_id, "start_time": start_time},
                     headers={"Authorization": f"Bearer {ha_token}"},
                 )
                 resp.raise_for_status()

--- a/web/services/hass_processor.py
+++ b/web/services/hass_processor.py
@@ -670,7 +670,8 @@ async def handle_energy_transfer(slug, new_state, ha_config, device_id, db):
     plug_data = attrs.get("plugDetails", {}) or {}
     plugged_in_duration_seconds = _safe_float(plug_data.get("totalPluggedInTime"))
     total_distance_added = _safe_float(plug_data.get("totalDistanceAdded"))
-    miles_added = normalize_value(total_distance_added, "mi", unit_system) if total_distance_added is not None else None
+    fordpass_dist_unit = ha_config.get("_fordpass_distance_unit", "km")
+    miles_added = total_distance_added / 1.60934 if (total_distance_added is not None and fordpass_dist_unit == "mi") else total_distance_added
 
     # State of charge
     soc_data = attrs.get("stateOfCharge", {}) or {}

--- a/web/templates/sessions/index.html
+++ b/web/templates/sessions/index.html
@@ -164,12 +164,12 @@ function toggleEditMode() {
 }
 
 function openSessionModal(sessionId) {
-    htmx.ajax('GET', '/sessions/' + sessionId + '/modal', {target: '#session-modal-content', swap: 'innerHTML'});
+    htmx.ajax('GET', '/charging/sessions/' + sessionId + '/modal', {target: '#session-modal-content', swap: 'innerHTML'});
     document.getElementById('session-modal').showModal();
 }
 
 function openNewSessionModal() {
-    htmx.ajax('GET', '/sessions/new/modal', {target: '#session-modal-content', swap: 'innerHTML'});
+    htmx.ajax('GET', '/charging/sessions/new/modal', {target: '#session-modal-content', swap: 'innerHTML'});
     document.getElementById('session-modal').showModal();
 }
 
@@ -180,7 +180,7 @@ function closeSessionModal() {
 
 function confirmDeleteFromModal(sessionId) {
     if (confirm('Are you sure you want to delete this session?')) {
-        htmx.ajax('DELETE', '/sessions/' + sessionId, {target: '#drawer-body', swap: 'innerHTML'});
+        htmx.ajax('DELETE', '/charging/sessions/' + sessionId, {target: '#drawer-body', swap: 'innerHTML'});
         closeSessionModal();
     }
 }
@@ -205,7 +205,7 @@ function highlightRow(sessionId) {
     var rows = document.querySelectorAll('#sessions-table-region tbody tr');
     rows.forEach(function(row) {
         var hxGet = row.getAttribute('hx-get');
-        if (hxGet && hxGet.includes('/sessions/' + sessionId + '/detail')) {
+        if (hxGet && hxGet.includes('/charging/sessions/' + sessionId + '/detail')) {
             row.classList.add('bg-blue-900/30');
             setTimeout(function() {
                 row.style.transition = 'background-color 2s ease-out';
@@ -329,7 +329,7 @@ function applyGroupEdit() {
     if (locInput.value) formData.append('bulk_location_name', locInput.value);
     if (costInput.value) formData.append('bulk_cost', costInput.value);
 
-    fetch('/sessions/bulk', {
+    fetch('/charging/sessions/bulk', {
         method: 'PUT',
         body: formData,
         headers: { 'HX-Request': 'true' }

--- a/web/templates/sessions/partials/drawer.html
+++ b/web/templates/sessions/partials/drawer.html
@@ -657,7 +657,7 @@
     <div class="pt-2">
         <button
             type="button"
-            onclick="if(confirm('Delete this session?')) { htmx.ajax('DELETE', '/sessions/{{ session.id }}', {swap:'none'}); closeDrawer(); }"
+            onclick="if(confirm('Delete this session?')) { htmx.ajax('DELETE', '/charging/sessions/{{ session.id }}', {swap:'none'}); closeDrawer(); }"
             class="btn btn-error btn-outline btn-sm w-full"
         >
             Delete Session


### PR DESCRIPTION
In no particular order - 

**hass_client.py**

• Fix backfill history API call, as the ```start_time``` was incorrectly passed in the URL path.  This caused backfill to always return empty results, but now it's fixed, allowing backfill. 

• Modified the way this detects the preferred units. You'd already inferred distance units from ```sensor.fordpass_{VIN}_elveh```, but you were also using that to infer temperature unit preferences. Since FordPass allows imperial and metric measurements to coexist (ie, one for distance, one for temperature), I added a way to detect preferred unit of temperature from ```sensor.fordpass_{VIN}_outsidetemp```

* Fixed the error reporting so ```last_error``` gets cleared on a successful reconnect so connection errors aren't persistent in the UI. 

**hass_processor.py**

As per [ earlier bug ](https://github.com/SquidBytes/LightningROD/issues/11), while the v0.3 code prior to this pull was figuring out proper unit, ```hass_processor.py``` was still misrepresenting distance. 

FordPass default to internally using metric, and then displaying it as imperial when imperial units are set. We know from the earlier fix when we're using miles, but now this fix was to normalize proper conversion. 

Now, ```_fordpass_distance_unit``` from ```ha_config``` is read, and passed on if metric units are used. If Imperial unit are used for distance, it divides the figure by 1.60934. 

**sessions/index.html and sessions/partials/drawer.html**

The new setup for v0.3 now uses a different URL methodology, but the html still had the old URLs for UI-based actions (delete, modal, edit, bulk and detail), resulting in 404 errors. This pull fixes them all to the new system. 