### PR TITLE
Unraid Setup - Add DATABASE_URL environment variable for PostgreSQL

### DIFF
--- a/docs/getting-started/unraid.md
+++ b/docs/getting-started/unraid.md
@@ -75,6 +75,7 @@ services:
     env_file: .env
     environment:
       - POSTGRES_HOST=db
+      - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Update docker-compose.yml to fix v0.4.0 database connection crashes

What this change does:
This updates the recommended Docker Compose documentation to explicitly construct the DATABASE_URL environment variable for the web service using string interpolation, and explicitly sets the scheme to postgresql+asyncpg://.

Why it is needed:

Pydantic Validation: Version 0.4.0+ requires a fully formed database_url string to initialize and will crash on startup if it is not passed to the container.

Asynchronous Driver Requirement: Using the standard postgresql:// scheme causes SQLAlchemy to look for the synchronous psycopg2 driver. Because this container is built for async operations, that driver is not installed, resulting in a ModuleNotFoundError. Defining postgresql+asyncpg:// correctly routes the connection through the installed asynchronous driver.

Hopefully, this saves the next person from spending their evening falling down the missing psycopg2 dependency rabbit hole.